### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-build-comment-read.yaml
+++ b/.github/workflows/docker-build-comment-read.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish comment-read to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/comment-read:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-comment-write.yaml
+++ b/.github/workflows/docker-build-comment-write.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish comment-write to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/comment-write:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-follow-read.yaml
+++ b/.github/workflows/docker-build-follow-read.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish follow-read to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/follow-read:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-follow-write.yaml
+++ b/.github/workflows/docker-build-follow-write.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish follow-write to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/follow-write:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-like-read.yaml
+++ b/.github/workflows/docker-build-like-read.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish like-read to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/like-read:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-login.yaml
+++ b/.github/workflows/docker-build-login.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish login to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/login:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-post-read.yaml
+++ b/.github/workflows/docker-build-post-read.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish post-read to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/post-read:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-post-write.yaml
+++ b/.github/workflows/docker-build-post-write.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish post-write to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/post-write:v1
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-build-signup.yaml
+++ b/.github/workflows/docker-build-signup.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish signup to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: saketthakare/signup:v1
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore